### PR TITLE
Ability to filter AdapterCommands

### DIFF
--- a/adaptercommands/src/main/java/com/hannesdorfmann/adaptercommands/command/DiffCommandsCalculator.java
+++ b/adaptercommands/src/main/java/com/hannesdorfmann/adaptercommands/command/DiffCommandsCalculator.java
@@ -91,6 +91,19 @@ public class DiffCommandsCalculator<T> {
   }
 
   /**
+   * This method calculates the difference between two lists.
+   * This method is <b>not thread safe</b>.
+   *
+   * @param newList The new items that we use to calculate the difference
+   * @return List of commands
+   * @see ThreadSafeDiffCommandsCalculator
+   */
+  public List<AdapterCommand> diff(@NonNull List<T> oldList, @NonNull List<T> newList) {
+    this.oldList = oldList;
+    return diff(newList);
+  }
+
+  /**
    * This method calculates the difference of previous list of items and the new list.
    * This method is <b>not thread safe</b>.
    *

--- a/adaptercommands/src/main/java/com/hannesdorfmann/adaptercommands/command/ThreadSafeDiffCommandsCalculator.java
+++ b/adaptercommands/src/main/java/com/hannesdorfmann/adaptercommands/command/ThreadSafeDiffCommandsCalculator.java
@@ -18,9 +18,7 @@ package com.hannesdorfmann.adaptercommands.command;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-
 import com.hannesdorfmann.adaptercommands.ItemChangedDetector;
-
 import java.util.List;
 
 /**
@@ -32,37 +30,42 @@ import java.util.List;
  */
 public class ThreadSafeDiffCommandsCalculator<T> extends DiffCommandsCalculator<T> {
 
-    public ThreadSafeDiffCommandsCalculator() {
-        super();
-    }
+  public ThreadSafeDiffCommandsCalculator() {
+    super();
+  }
 
-    public ThreadSafeDiffCommandsCalculator(boolean itemRangeInsertedOnFirstDiff) {
-        super(itemRangeInsertedOnFirstDiff);
-    }
+  public ThreadSafeDiffCommandsCalculator(boolean itemRangeInsertedOnFirstDiff) {
+    super(itemRangeInsertedOnFirstDiff);
+  }
 
-    public ThreadSafeDiffCommandsCalculator(ItemChangedDetector<T> detector) {
-        super(detector);
-    }
+  public ThreadSafeDiffCommandsCalculator(ItemChangedDetector<T> detector) {
+    super(detector);
+  }
 
-    public ThreadSafeDiffCommandsCalculator(boolean itemRangeInsertedOnFirstDiff,
-                                            @Nullable ItemChangedDetector<T> detector) {
-        super(itemRangeInsertedOnFirstDiff, detector);
-    }
+  public ThreadSafeDiffCommandsCalculator(boolean itemRangeInsertedOnFirstDiff,
+      @Nullable ItemChangedDetector<T> detector) {
+    super(itemRangeInsertedOnFirstDiff, detector);
+  }
 
-    @Override
-    public synchronized List<AdapterCommand> diff(@NonNull List<T> oldList, @NonNull List<T> newList) {
-        return super.diff(oldList, newList);
-    }
+  /**
+   * This method calculates the difference between two lists.
+   * This call is thread safe
+   *
+   * @param newList The new items that we use to calculate the difference
+   * @return List of commands
+   */
+  @Override public synchronized List<AdapterCommand> diff(@NonNull List<T> oldList, @NonNull List<T> newList) {
+    return super.diff(oldList, newList);
+  }
 
-    /**
-     * This method calculates the difference of previous list of items and the new list.
-     * This call is thread safe
-     *
-     * @param newList The new items that we use to calculate the difference
-     * @return List of commands
-     */
-    @Override
-    public synchronized List<AdapterCommand> diff(@NonNull List<T> newList) {
-        return super.diff(newList);
-    }
+  /**
+   * This method calculates the difference of previous list of items and the new list.
+   * This call is thread safe
+   *
+   * @param newList The new items that we use to calculate the difference
+   * @return List of commands
+   */
+  @Override public synchronized List<AdapterCommand> diff(@NonNull List<T> newList) {
+    return super.diff(newList);
+  }
 }

--- a/adaptercommands/src/main/java/com/hannesdorfmann/adaptercommands/command/ThreadSafeDiffCommandsCalculator.java
+++ b/adaptercommands/src/main/java/com/hannesdorfmann/adaptercommands/command/ThreadSafeDiffCommandsCalculator.java
@@ -18,7 +18,9 @@ package com.hannesdorfmann.adaptercommands.command;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+
 import com.hannesdorfmann.adaptercommands.ItemChangedDetector;
+
 import java.util.List;
 
 /**
@@ -30,31 +32,37 @@ import java.util.List;
  */
 public class ThreadSafeDiffCommandsCalculator<T> extends DiffCommandsCalculator<T> {
 
-  public ThreadSafeDiffCommandsCalculator() {
-    super();
-  }
+    public ThreadSafeDiffCommandsCalculator() {
+        super();
+    }
 
-  public ThreadSafeDiffCommandsCalculator(boolean itemRangeInsertedOnFirstDiff) {
-    super(itemRangeInsertedOnFirstDiff);
-  }
+    public ThreadSafeDiffCommandsCalculator(boolean itemRangeInsertedOnFirstDiff) {
+        super(itemRangeInsertedOnFirstDiff);
+    }
 
-  public ThreadSafeDiffCommandsCalculator(ItemChangedDetector<T> detector) {
-    super(detector);
-  }
+    public ThreadSafeDiffCommandsCalculator(ItemChangedDetector<T> detector) {
+        super(detector);
+    }
 
-  public ThreadSafeDiffCommandsCalculator(boolean itemRangeInsertedOnFirstDiff,
-      @Nullable ItemChangedDetector<T> detector) {
-    super(itemRangeInsertedOnFirstDiff, detector);
-  }
+    public ThreadSafeDiffCommandsCalculator(boolean itemRangeInsertedOnFirstDiff,
+                                            @Nullable ItemChangedDetector<T> detector) {
+        super(itemRangeInsertedOnFirstDiff, detector);
+    }
 
-  /**
-   * This method calculates the difference of previous list of items and the new list.
-   * This call is thread safe
-   *
-   * @param newList The new items that we use to calculate the difference
-   * @return List of commands
-   */
-  @Override public synchronized List<AdapterCommand> diff(@NonNull List<T> newList) {
-    return super.diff(newList);
-  }
+    @Override
+    public synchronized List<AdapterCommand> diff(@NonNull List<T> oldList, @NonNull List<T> newList) {
+        return super.diff(oldList, newList);
+    }
+
+    /**
+     * This method calculates the difference of previous list of items and the new list.
+     * This call is thread safe
+     *
+     * @param newList The new items that we use to calculate the difference
+     * @return List of commands
+     */
+    @Override
+    public synchronized List<AdapterCommand> diff(@NonNull List<T> newList) {
+        return super.diff(newList);
+    }
 }


### PR DESCRIPTION
I am in a scenario where I want to filter delete commands. If I do so, I enter an inconsistent state since oldList now thinks all deletes were executed.

Since oldList is private, I cannot get away with composition. As an alternative to the PR I made providing an overload method to provide "oldList". You could also opt to make oldList protected so I could use composition to add this behaviour myself which perhaps would be less confusing for users of your library.

Hope to hear back from you.

Thanks