### PR TITLE
Remove attributes from the Manifest

### DIFF
--- a/adaptercommands/src/main/AndroidManifest.xml
+++ b/adaptercommands/src/main/AndroidManifest.xml
@@ -14,15 +14,4 @@
   ~ limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.hannesdorfmann.adaptercommands">
-
-  <application
-      android:allowBackup="true"
-      android:label="@string/app_name"
-      android:supportsRtl="true"
-      >
-
-  </application>
-
-</manifest>
+<manifest package="com.hannesdorfmann.adaptercommands"/>


### PR DESCRIPTION
Including these definitions forces the manifest merger to fail if any of the attributes conflict.

<img width="853" alt="screen shot 2017-02-01 at 12 44 01" src="https://cloud.githubusercontent.com/assets/898078/22505631/cf629108-e87c-11e6-9d40-41d9dc59da39.png">

If conflicts don't exist then the consumers of the lib will use the attributes defined here.

So this PR removes this

